### PR TITLE
customizations: return `nil` for empty user customization

### DIFF
--- a/pkg/blueprint/blueprint_convert_test.go
+++ b/pkg/blueprint/blueprint_convert_test.go
@@ -20,6 +20,15 @@ func TestConvert(t *testing.T) {
 			expected: iblueprint.Blueprint{},
 		},
 		{
+			name: "almost-empty",
+			src: Blueprint{
+				Customizations: &Customizations{},
+			},
+			expected: iblueprint.Blueprint{
+				Customizations: &iblueprint.Customizations{},
+			},
+		},
+		{
 			name: "everything",
 			src: Blueprint{
 				Name:        "name",

--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -231,7 +231,7 @@ func (c *Customizations) GetUsers() []UserCustomization {
 		return nil
 	}
 
-	users := []UserCustomization{}
+	var users []UserCustomization
 
 	// prepend sshkey for backwards compat (overridden by users)
 	if len(c.SSHKey) > 0 {


### PR DESCRIPTION
Return `nil` for the user customization when there are no users instead of creating a slice of size nil. This is just easier in tests and more idiomatic (a `nil` list is fine).