### PR TITLE
blueprint: import our own blueprints in our tests

### DIFF
--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"github.com/osbuild/images/pkg/blueprint"
-	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/pathpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/pathpolicy"
+
+	"github.com/osbuild/blueprint/pkg/blueprint"
 )
 
 func TestPartitioningValidation(t *testing.T) {


### PR DESCRIPTION
This commit fixes an oversight when the images based blueprints tests got merged. We need to import our own blueprints in the disk_customizations_test.go instead of the (deprecated) images ones.