### PR TITLE
customizations: import new `pkg/partition` from images

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/osbuild/images/pkg/cert"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
-	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/disk/partition"
 )
 
 type Customizations struct {
@@ -346,22 +346,22 @@ func (c *Customizations) GetPartitioning() (*DiskCustomization, error) {
 }
 
 // GetPartitioningMode converts the string to a disk.PartitioningMode type
-func (c *Customizations) GetPartitioningMode() (disk.PartitioningMode, error) {
+func (c *Customizations) GetPartitioningMode() (partition.PartitioningMode, error) {
 	if c == nil {
-		return disk.DefaultPartitioningMode, nil
+		return partition.DefaultPartitioningMode, nil
 	}
 
 	switch c.PartitioningMode {
 	case "raw":
-		return disk.RawPartitioningMode, nil
+		return partition.RawPartitioningMode, nil
 	case "lvm":
-		return disk.LVMPartitioningMode, nil
+		return partition.LVMPartitioningMode, nil
 	case "auto-lvm":
-		return disk.AutoLVMPartitioningMode, nil
+		return partition.AutoLVMPartitioningMode, nil
 	case "":
-		return disk.DefaultPartitioningMode, nil
+		return partition.DefaultPartitioningMode, nil
 	default:
-		return disk.DefaultPartitioningMode, fmt.Errorf("invalid partitioning mode '%s'", c.PartitioningMode)
+		return partition.DefaultPartitioningMode, fmt.Errorf("invalid partitioning mode '%s'", c.PartitioningMode)
 	}
 }
 

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -3,12 +3,12 @@ package blueprint
 import (
 	"testing"
 
-	"github.com/osbuild/blueprint/internal/common"
-	"github.com/osbuild/images/pkg/disk"
+	"github.com/osbuild/images/pkg/customizations/anaconda"
+	"github.com/osbuild/images/pkg/disk/partition"
+	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/osbuild/images/pkg/customizations/anaconda"
-	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/blueprint/internal/common"
 )
 
 func TestCheckAllowed(t *testing.T) {
@@ -325,14 +325,14 @@ func TestGetPartitioningMode(t *testing.T) {
 	var c *Customizations
 	pm, err := c.GetPartitioningMode()
 	assert.NoError(t, err)
-	assert.Equal(t, disk.DefaultPartitioningMode, pm)
+	assert.Equal(t, partition.DefaultPartitioningMode, pm)
 
 	// Empty defaults to Default which is actually AutoLVM,
 	// but that is handled by the images code
 	c = &Customizations{}
 	_, err = c.GetPartitioningMode()
 	assert.NoError(t, err)
-	assert.Equal(t, disk.DefaultPartitioningMode, pm)
+	assert.Equal(t, partition.DefaultPartitioningMode, pm)
 
 	// Unknown mode returns an error
 	c = &Customizations{
@@ -347,7 +347,7 @@ func TestGetPartitioningMode(t *testing.T) {
 	}
 	pm, err = c.GetPartitioningMode()
 	assert.NoError(t, err)
-	assert.Equal(t, disk.LVMPartitioningMode, pm)
+	assert.Equal(t, partition.LVMPartitioningMode, pm)
 }
 
 func TestGetRHSM(t *testing.T) {


### PR DESCRIPTION
[edit: converted to draft as there is concern about the whole approach used in https://github.com/osbuild/images/pull/1552]

This is needed to avoid a circular import when we use the blueprint package as an import in the "images" library.

Needs https://github.com/osbuild/images/pull/1551