### PR TITLE
blueprint: add AutoEnableYumPlugins

### DIFF
--- a/pkg/blueprint/rhsm_customizations.go
+++ b/pkg/blueprint/rhsm_customizations.go
@@ -2,7 +2,8 @@ package blueprint
 
 // Subscription Manager [rhsm] configuration
 type SubManRHSMConfig struct {
-	ManageRepos *bool `json:"manage_repos,omitempty" toml:"manage_repos,omitempty"`
+	ManageRepos          *bool `json:"manage_repos,omitempty" toml:"manage_repos,omitempty"`
+	AutoEnableYumPlugins *bool `json:"auto_enable_yum_plugins,omitempty" toml:"auto_enable_yum_plugins,omitemty"`
 }
 
 // Subscription Manager [rhsmcertd] configuration


### PR DESCRIPTION
[draft as I think we need to add this to Convert() but then maybe we can just move everything to the new blueprint package and can drop Convert()?]

This is the coresponding change of
https://github.com/osbuild/images/pull/1415
for the blueprint library.
