### PR TITLE
disk: fix typo in TOML go tag

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -20,7 +20,7 @@ type DiskCustomization struct {
 	// Optional, the default depends on the distro and image type.
 	Type       string                   `json:"type,omitempty" toml:"type,omitempty"`
 	MinSize    uint64                   `json:"minsize,omitempty" toml:"minsize,omitempty"`
-	Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"minsize,omitempty"`
+	Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
 }
 
 type diskCustomizationMarshaler struct {


### PR DESCRIPTION
Found by @bcl thanks.

I thought for a moment TOML is really a crazy format, could not wrap my head around what I saw:

```toml
[customizations.disk]
type = "gpt"
minsize = 161061273600

[[customizations.disk.minsize]]
type = "plain"
minsize = 53687091200
mountpoint = "/"
label = "label"
fs_type = "ext4"

[[customizations.disk.minsize]]
type = "lvm"
minsize = 53687091200
name = "vg_name"
```