### PR TITLE
blueprint: copy over the partition table type when converting

### DIFF
--- a/pkg/blueprint/blueprint.go
+++ b/pkg/blueprint/blueprint.go
@@ -354,6 +354,7 @@ func Convert(bp Blueprint) iblueprint.Blueprint {
 		}
 		if disk := c.Disk; disk != nil {
 			idisk := &iblueprint.DiskCustomization{
+				Type:       disk.Type,
 				MinSize:    disk.MinSize,
 				Partitions: make([]iblueprint.PartitionCustomization, len(disk.Partitions)),
 			}

--- a/pkg/blueprint/blueprint_convert_test.go
+++ b/pkg/blueprint/blueprint_convert_test.go
@@ -130,6 +130,7 @@ func TestConvert(t *testing.T) {
 						},
 					},
 					Disk: &DiskCustomization{
+						Type:    "dos",
 						MinSize: 10240,
 						Partitions: []PartitionCustomization{
 							{
@@ -447,6 +448,7 @@ func TestConvert(t *testing.T) {
 						},
 					},
 					Disk: &iblueprint.DiskCustomization{
+						Type:    "dos",
 						MinSize: 10240,
 						Partitions: []iblueprint.PartitionCustomization{
 							{


### PR DESCRIPTION
We missed this and it's making it impossible to set the PT type.