### PR TITLE
blueprint: adopt PartitioningMode type from osbuild/images

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/osbuild/images/pkg/cert"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
-	"github.com/osbuild/images/pkg/disk/partition"
 )
 
 type Customizations struct {
@@ -343,26 +342,6 @@ func (c *Customizations) GetPartitioning() (*DiskCustomization, error) {
 	}
 
 	return c.Disk, nil
-}
-
-// GetPartitioningMode converts the string to a disk.PartitioningMode type
-func (c *Customizations) GetPartitioningMode() (partition.PartitioningMode, error) {
-	if c == nil {
-		return partition.DefaultPartitioningMode, nil
-	}
-
-	switch c.PartitioningMode {
-	case "raw":
-		return partition.RawPartitioningMode, nil
-	case "lvm":
-		return partition.LVMPartitioningMode, nil
-	case "auto-lvm":
-		return partition.AutoLVMPartitioningMode, nil
-	case "":
-		return partition.DefaultPartitioningMode, nil
-	default:
-		return partition.DefaultPartitioningMode, fmt.Errorf("invalid partitioning mode '%s'", c.PartitioningMode)
-	}
 }
 
 func (c *Customizations) GetInstallationDevice() string {

--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/osbuild/blueprint/internal/common"
 	"github.com/osbuild/images/pkg/customizations/anaconda"
-	"github.com/osbuild/images/pkg/disk/partition"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -325,14 +324,14 @@ func TestGetPartitioningMode(t *testing.T) {
 	var c *Customizations
 	pm, err := c.GetPartitioningMode()
 	assert.NoError(t, err)
-	assert.Equal(t, partition.DefaultPartitioningMode, pm)
+	assert.Equal(t, DefaultPartitioningMode, pm)
 
 	// Empty defaults to Default which is actually AutoLVM,
 	// but that is handled by the images code
 	c = &Customizations{}
 	_, err = c.GetPartitioningMode()
 	assert.NoError(t, err)
-	assert.Equal(t, partition.DefaultPartitioningMode, pm)
+	assert.Equal(t, DefaultPartitioningMode, pm)
 
 	// Unknown mode returns an error
 	c = &Customizations{
@@ -347,7 +346,7 @@ func TestGetPartitioningMode(t *testing.T) {
 	}
 	pm, err = c.GetPartitioningMode()
 	assert.NoError(t, err)
-	assert.Equal(t, partition.LVMPartitioningMode, pm)
+	assert.Equal(t, LVMPartitioningMode, pm)
 }
 
 func TestGetRHSM(t *testing.T) {

--- a/pkg/blueprint/partitioning_mode.go
+++ b/pkg/blueprint/partitioning_mode.go
@@ -1,0 +1,46 @@
+package blueprint
+
+import (
+	"fmt"
+)
+
+type PartitioningMode string
+
+const (
+	// AutoLVMPartitioningMode creates a LVM layout if the filesystem
+	// contains a mountpoint that's not defined in the base partition table
+	// of the specified image type. In the other case, a raw layout is used.
+	AutoLVMPartitioningMode PartitioningMode = "auto-lvm"
+
+	// LVMPartitioningMode always creates an LVM layout.
+	LVMPartitioningMode PartitioningMode = "lvm"
+
+	// RawPartitioningMode always creates a raw layout.
+	RawPartitioningMode PartitioningMode = "raw"
+
+	// BtrfsPartitioningMode creates a btrfs layout.
+	BtrfsPartitioningMode PartitioningMode = "btrfs"
+
+	// DefaultPartitioningMode is AutoLVMPartitioningMode and is the empty state
+	DefaultPartitioningMode PartitioningMode = ""
+)
+
+// GetPartitioningMode converts the string to a disk.PartitioningMode type
+func (c *Customizations) GetPartitioningMode() (PartitioningMode, error) {
+	if c == nil {
+		return DefaultPartitioningMode, nil
+	}
+
+	switch c.PartitioningMode {
+	case "raw":
+		return RawPartitioningMode, nil
+	case "lvm":
+		return LVMPartitioningMode, nil
+	case "auto-lvm":
+		return AutoLVMPartitioningMode, nil
+	case "":
+		return DefaultPartitioningMode, nil
+	default:
+		return DefaultPartitioningMode, fmt.Errorf("invalid partitioning mode '%s'", c.PartitioningMode)
+	}
+}


### PR DESCRIPTION
We want to move the PartitioningMode out of osbuild/images and into this repository.  The type definition and its getter are moved to a new file, partitioning_mode.go.

See https://github.com/osbuild/images/issues/1731