### PR TITLE
installer: add `menu-timeout` (HMS-9044)

### DIFF
--- a/pkg/blueprint/installer_customizations.go
+++ b/pkg/blueprint/installer_customizations.go
@@ -1,10 +1,11 @@
 package blueprint
 
 type InstallerCustomization struct {
-	Unattended   bool             `json:"unattended,omitempty" toml:"unattended,omitempty"`
-	SudoNopasswd []string         `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
-	Kickstart    *Kickstart       `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
-	Modules      *AnacondaModules `json:"modules,omitempty" toml:"modules,omitempty"`
+	Unattended   bool                 `json:"unattended,omitempty" toml:"unattended,omitempty"`
+	SudoNopasswd []string             `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
+	Kickstart    *Kickstart           `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
+	Modules      *AnacondaModules     `json:"modules,omitempty" toml:"modules,omitempty"`
+	Bootloader   *InstallerBootloader `json:"bootloader,omitempty" toml:"bootloader,omitempty"`
 }
 
 type Kickstart struct {
@@ -14,4 +15,12 @@ type Kickstart struct {
 type AnacondaModules struct {
 	Enable  []string `json:"enable,omitempty" toml:"enable,omitempty"`
 	Disable []string `json:"disable,omitempty" toml:"disable,omitempty"`
+}
+
+type InstallerBootloader struct {
+	Grub2 *InstallerGrub2 `json:"grub2,omitempty" toml:"grub2,omitempty"`
+}
+
+type InstallerGrub2 struct {
+	MenuTimeout *int `json:"menu-timeout,omitempty" toml:"menu-timeout,omitempty"`
 }


### PR DESCRIPTION
Add a new property for the `installer` section which will be wired up to configure the GRUB2 menu timeout for ISOs. As requested/discussed here: https://github.com/orgs/osbuild/discussions/44 and in the linked JIRA issue above.