### PR TITLE
disk: allow `start_offset`

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -19,15 +19,17 @@ import (
 type DiskCustomization struct {
 	// Type of the partition table: gpt or dos.
 	// Optional, the default depends on the distro and image type.
-	Type       string                   `json:"type,omitempty" toml:"type,omitempty"`
-	MinSize    uint64                   `json:"minsize,omitempty,omitzero" toml:"minsize,omitempty,omitzero"`
-	Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
+	Type        string                   `json:"type,omitempty" toml:"type,omitempty"`
+	MinSize     uint64                   `json:"minsize,omitempty,omitzero" toml:"minsize,omitempty,omitzero"`
+	Partitions  []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
+	StartOffset uint64                   `json:"start_offset,omitempty" toml:"start_offset,omitempty"`
 }
 
 type diskCustomizationMarshaler struct {
-	Type       string                   `json:"type,omitempty" toml:"type,omitempty"`
-	MinSize    datasizes.Size           `json:"minsize,omitempty" toml:"minsize,omitempty"`
-	Partitions []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
+	Type        string                   `json:"type,omitempty" toml:"type,omitempty"`
+	MinSize     datasizes.Size           `json:"minsize,omitempty" toml:"minsize,omitempty"`
+	Partitions  []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
+	StartOffset datasizes.Size           `json:"start_offset,omitempty" toml:"start_offset,omitempty"`
 }
 
 func (dc *DiskCustomization) UnmarshalJSON(data []byte) error {
@@ -38,6 +40,7 @@ func (dc *DiskCustomization) UnmarshalJSON(data []byte) error {
 	dc.Type = dcm.Type
 	dc.MinSize = dcm.MinSize.Uint64()
 	dc.Partitions = dcm.Partitions
+	dc.StartOffset = dcm.StartOffset.Uint64()
 
 	return nil
 }

--- a/pkg/blueprint/disk_customizations_test.go
+++ b/pkg/blueprint/disk_customizations_test.go
@@ -39,6 +39,20 @@ func TestPartitioningValidation(t *testing.T) {
 			},
 			expectedMsg: "",
 		},
+		"happy-plain+offset": {
+			partitioning: &blueprint.DiskCustomization{
+				StartOffset: 8 * datasizes.MiB,
+				Partitions: []blueprint.PartitionCustomization{
+					{
+						FilesystemTypedCustomization: blueprint.FilesystemTypedCustomization{
+							FSType:     "xfs",
+							Mountpoint: "/data",
+						},
+					},
+				},
+			},
+			expectedMsg: "",
+		},
 		"happy-plain+btrfs+swap": {
 			partitioning: &blueprint.DiskCustomization{
 				Partitions: []blueprint.PartitionCustomization{
@@ -2020,6 +2034,33 @@ func TestDiskCustomizationUnmarshalJSON(t *testing.T) {
 			inputTOML: `minsize = "1 GiB"`,
 			expected: &blueprint.DiskCustomization{
 				MinSize: 1 * datasizes.GiB,
+			},
+		},
+		"start_offset/int": {
+			inputJSON: `{
+				"start_offset": 1234
+			}`,
+			inputTOML: "start_offset = 1234",
+			expected: &blueprint.DiskCustomization{
+				StartOffset: 1234,
+			},
+		},
+		"start_offset/str": {
+			inputJSON: `{
+				"start_offset": "1234"
+			}`,
+			inputTOML: `start_offset = "1234"`,
+			expected: &blueprint.DiskCustomization{
+				StartOffset: 1234,
+			},
+		},
+		"start_offset/str-with-unit": {
+			inputJSON: `{
+				"start_offset": "1 GiB"
+			}`,
+			inputTOML: `start_offset = "1 GiB"`,
+			expected: &blueprint.DiskCustomization{
+				StartOffset: 1 * datasizes.GiB,
 			},
 		},
 		"type": {


### PR DESCRIPTION
Allow for the control of the `start_offset` variable for partition tables. This approach lets users free up room at the start of a disk to potentially write firmware or other bits and bobs as requested in [1].

[1]: https://github.com/osbuild/images/issues/1578

---

Opening this as a draft for https://github.com/osbuild/images/issues/1578, the alternative solution (but we might want both!) is in: https://github.com/osbuild/images/pull/1888 which moves all partition offsets a bit making the default case work. This PR then allows users to go further if necessary.