### PR TITLE
blueprint: new customization: dnf

### DIFF
--- a/pkg/blueprint/customizations.go
+++ b/pkg/blueprint/customizations.go
@@ -37,6 +37,7 @@ type Customizations struct {
 	CACerts            *CACustomization               `json:"cacerts,omitempty" toml:"cacerts,omitempty"`
 	ContainersStorage  *ContainerStorageCustomization `json:"containers-storage,omitempty" toml:"containers-storage,omitempty"`
 	Firstboot          *FirstbootCustomization        `json:"firstboot,omitempty" toml:"firstboot,omitempty"`
+	DNF                *DNFCustomization              `json:"dnf,omitempty" toml:"dnf,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -150,6 +151,14 @@ type CACustomization struct {
 type ContainerStorageCustomization struct {
 	// destination is always `containers-storage`, so we won't expose this
 	StoragePath *string `json:"destination-path,omitempty" toml:"destination-path,omitempty"`
+}
+
+type DNFCustomization struct {
+	Config *DNFConfigCustomization `json:"config,omitempty" toml:"config,omitempty"`
+}
+
+type DNFConfigCustomization struct {
+	SetReleaseVer bool `json:"set_releasever,omitempty" toml:"set_releasever,omitempty"`
 }
 
 type CustomizationError struct {
@@ -485,4 +494,11 @@ func (c *Customizations) GetCACerts() (*CACustomization, error) {
 	}
 
 	return c.CACerts, nil
+}
+
+func (c *Customizations) GetDNF() *DNFCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.DNF
 }


### PR DESCRIPTION
New dnf customization block that enables one option for now: set_releasever.  The option is meant to set the releasever dnf variable to the value of the distro's release version, which ties a system to a specific update of RHEL.  This prevents a system from being updated to a later minor RHEL release through `dnf upgrade` and is the mechanism for keeping systems on extended support releases (EUS and E4S).

The dnf customization block is created so that it might later be used for other variables (perhaps even arbitrary, user-defined variables). However, the releasever variable will be treated separately so that it can be a simple switch that sets the `releasever` value to the one for the image's distro dynamically.

The config key `set_releasever` was chosen over `set_release_ver` because the variable name is `releasever` and it is more consistent with other user-facing use cases where it is treated as a single word.