### PR TITLE
add new bootmode customization to blueprint

### DIFF
--- a/pkg/blueprint/disk_customizations.go
+++ b/pkg/blueprint/disk_customizations.go
@@ -20,6 +20,7 @@ type DiskCustomization struct {
 	// Type of the partition table: gpt or dos.
 	// Optional, the default depends on the distro and image type.
 	Type        string                   `json:"type,omitempty" toml:"type,omitempty"`
+	BootMode    string                   `json:"bootmode,omitempty" toml:"bootmode,omitempty"`
 	MinSize     uint64                   `json:"minsize,omitempty,omitzero" toml:"minsize,omitempty,omitzero"`
 	Partitions  []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
 	StartOffset uint64                   `json:"start_offset,omitempty" toml:"start_offset,omitempty"`
@@ -27,6 +28,7 @@ type DiskCustomization struct {
 
 type diskCustomizationMarshaler struct {
 	Type        string                   `json:"type,omitempty" toml:"type,omitempty"`
+	BootMode    string                   `json:"bootmode,omitempty" toml:"bootmode,omitempty"`
 	MinSize     datasizes.Size           `json:"minsize,omitempty" toml:"minsize,omitempty"`
 	Partitions  []PartitionCustomization `json:"partitions,omitempty" toml:"partitions,omitempty"`
 	StartOffset datasizes.Size           `json:"start_offset,omitempty" toml:"start_offset,omitempty"`
@@ -36,6 +38,9 @@ func (dc *DiskCustomization) UnmarshalJSON(data []byte) error {
 	var dcm diskCustomizationMarshaler
 	if err := json.Unmarshal(data, &dcm); err != nil {
 		return err
+	}
+	if dcm.BootMode != "" {
+		dc.BootMode = dcm.BootMode
 	}
 	dc.Type = dcm.Type
 	dc.MinSize = dcm.MinSize.Uint64()


### PR DESCRIPTION
When using the bootc-image-builder we found that when creating a bootc-based Fedora IoT image a 1 MiB bootable partition was inserted at the start of the disk image. For our Raspberry Pi-based project we desire a DOS MBR partition table where the first partition is large enough to hold the initial bootloader and the device tree overlays. Since this does not fit inside the 1 MiB partition, and the Raspberry Pi is unable to locate the boot loader and device tree overlays when they are located on the second partition of the disk, we designed a method for optionally customizing the "boot mode" through the blueprint.

This pull request defines a way to customize the "boot mode" of a disk image through the blueprint. Another pull request is made to the images repo[1] to consume the new customization.

[1]: https://github.com/osbuild/images/pull/1923
