### PR TITLE
installer: payload/flatpaks customizations (HMS-10433)

### DIFF
--- a/pkg/blueprint/customizations_test.go
+++ b/pkg/blueprint/customizations_test.go
@@ -375,6 +375,21 @@ func TestGetInstallerErrors(t *testing.T) {
 						Enable:  []string{anaconda.ModuleUsers},
 						Disable: []string{anaconda.ModuleSecurity},
 					},
+					Payload: &InstallerPayload{
+						Flatpaks: &FlatpakMeta{
+							Force: []Flatpak{
+								Flatpak{
+									Registry: &FlatpakRegistry{
+										RemoteName: "fedora",
+										URL:        "oci+https://registry.fedoraproject.org",
+									},
+									References: []string{
+										"app/org.kde.skanpage/x86_64/stable",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/blueprint/installer_customizations.go
+++ b/pkg/blueprint/installer_customizations.go
@@ -6,6 +6,7 @@ type InstallerCustomization struct {
 	Kickstart    *Kickstart           `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
 	Modules      *AnacondaModules     `json:"modules,omitempty" toml:"modules,omitempty"`
 	Bootloader   *InstallerBootloader `json:"bootloader,omitempty" toml:"bootloader,omitempty"`
+	Payload      *InstallerPayload    `json:"payload,omitempty" toml:"payload,omitempty"`
 }
 
 type Kickstart struct {
@@ -23,4 +24,22 @@ type InstallerBootloader struct {
 
 type InstallerGrub2 struct {
 	MenuTimeout *int `json:"menu-timeout,omitempty" toml:"menu-timeout,omitempty"`
+}
+
+type InstallerPayload struct {
+	Flatpaks *FlatpakMeta `json:"flatpaks,omitempty" toml:"flatpaks,omitempty"`
+}
+
+type FlatpakMeta struct {
+	Force []Flatpak `json:"force,omitempty" toml:"force,omitempty"`
+}
+
+type Flatpak struct {
+	Registry   *FlatpakRegistry `json:"registry,omitempty" toml:"registry,omitempty"`
+	References []string         `json:"references,omitempty" toml:"references,omitempty"`
+}
+
+type FlatpakRegistry struct {
+	RemoteName string `json:"remote_name,omitempty" toml:"remote_name,omitempty"`
+	URL        string `json:"url,omitempty" toml:"url,omitempty"`
 }


### PR DESCRIPTION
For Fedora Atomic variants we'll need to be able to define the flatpaks that get written to the payload part of the ISO. This is different from (potentially) in the future having flatpaks that are used in the ISO environment.

This is why I put them in a `payload`-subsection where we can have more options to adjust payloads.

They're also embedded a bit deeper by adding a `force` (terminology borrowed from `image-builder`) struct which means that they will fully override any preset flatpaks in the image definitions.

All of this is necessary as we need to be able to define flatpaks in the blueprint so they can be configured through Pungi. The flatpak runtime releases are out of sync with normal Fedora branching and thus their versions are not the same as the current 'majorversion' or such. See for an example PR in pungi-fedora [1].

[1]: https://forge.fedoraproject.org/releng/pungi-fedora/pulls/1626/files