### PR TITLE
blueprint: add After/Before fields to firstboot customizations (HMS-9187)

### DIFF
--- a/pkg/blueprint/firstboot_customizations.go
+++ b/pkg/blueprint/firstboot_customizations.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+// FirstbootCustomization specifies firstboot customizations to be executed
+// during the firstboot process. They are processed in order and if one of them
+// fails, the execution stops immediately. Scripts are executed via systemd and
+// their absolute ordering can be influenced by the `After/Before` fields.
 type FirstbootCustomization struct {
 	Scripts []FirstbootScriptCustomization `json:"scripts,omitempty" toml:"scripts,omitempty"`
 }
@@ -31,6 +35,20 @@ type FirstbootCommonCustomization struct {
 	// firstboot scripts are executed in order and if one of them fails, the
 	// execution stops immediately.
 	IgnoreFailure bool `json:"ignore_failure,omitempty" toml:"ignore_failure,omitempty"`
+
+	// Systemd After= ordering: startup of this firstboot job is ordered after the
+	// listed units when they participate in the same transaction. Each entry must
+	// be a full unit name, e.g. "network-online.target". This does not by itself add
+	// Requires= or Wants=; see systemd.unit(5). Relative order among firstboot
+	// scripts in the blueprint is still preserved.
+	After []string `json:"after,omitempty" toml:"after,omitempty"`
+
+	// Systemd Before= ordering: startup of this firstboot job is ordered before the
+	// listed units when they participate in the same transaction. Each entry must
+	// be a full unit name, e.g. "postgresql.service". This does not by itself add
+	// Requires= or Wants=; see systemd.unit(5). Relative order among firstboot
+	// scripts in the blueprint is still preserved.
+	Before []string `json:"before,omitempty" toml:"before,omitempty"`
 }
 
 // CustomFirstbootCustomization contains fields specific to custom firstboot

--- a/pkg/blueprint/firstboot_customizations_test.go
+++ b/pkg/blueprint/firstboot_customizations_test.go
@@ -42,6 +42,13 @@ func TestJSON(t *testing.T) {
 				union: json.RawMessage(`{"type":"unknown","name":"test"}`),
 			},
 		},
+		{
+			name: "custom-with-after-before",
+			json: `{"type":"custom","name":"test","after":["network-online.target"],"before":["postgresql.service"],"contents":"echo hello"}`,
+			field: FirstbootScriptCustomization{
+				union: json.RawMessage(`{"type":"custom","name":"test","after":["network-online.target"],"before":["postgresql.service"],"contents":"echo hello"}`),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -98,6 +105,17 @@ job_template_url = "https://aap.example.com/api/v2/job_templates/9/callback/"`,
 name = "test"`,
 			field: FirstbootScriptCustomization{
 				union: json.RawMessage(`{"type":"unknown","name":"test"}`),
+			},
+		},
+		{
+			name: "custom-with-after-before",
+			toml: `type = "custom"
+name = "test"
+after = ["network-online.target"]
+before = ["postgresql.service"]
+contents = "echo hello"`,
+			field: FirstbootScriptCustomization{
+				union: json.RawMessage(`{"type":"custom","name":"test","after":["network-online.target"],"before":["postgresql.service"],"contents":"echo hello"}`),
 			},
 		},
 	}
@@ -169,6 +187,24 @@ contents = "echo hello"`,
 			},
 		},
 		{
+			name: "custom-with-after-before",
+			json: `{"type":"custom","name":"test","after":["network-online.target"],"before":["postgresql.service"],"contents":"echo hello"}`,
+			toml: `type = "custom"
+name = "test"
+after = ["network-online.target"]
+before = ["postgresql.service"]
+contents = "echo hello"`,
+			expectedCustom: &CustomFirstbootCustomization{
+				FirstbootCommonCustomization: FirstbootCommonCustomization{
+					Type:   "custom",
+					Name:   "test",
+					After:  []string{"network-online.target"},
+					Before: []string{"postgresql.service"},
+				},
+				Contents: "echo hello",
+			},
+		},
+		{
 			name: "satellite",
 			json: `{"type":"satellite","name":"test","command":"echo hello"}`,
 			toml: `type = "satellite"
@@ -178,6 +214,22 @@ command = "echo hello"`,
 				FirstbootCommonCustomization: FirstbootCommonCustomization{
 					Type: "satellite",
 					Name: "test",
+				},
+				Command: "echo hello",
+			},
+		},
+		{
+			name: "satellite-with-after",
+			json: `{"type":"satellite","name":"test","after":["network-online.target"],"command":"echo hello"}`,
+			toml: `type = "satellite"
+name = "test"
+after = ["network-online.target"]
+command = "echo hello"`,
+			expectedSatellite: &SatelliteFirstbootCustomization{
+				FirstbootCommonCustomization: FirstbootCommonCustomization{
+					Type:  "satellite",
+					Name:  "test",
+					After: []string{"network-online.target"},
 				},
 				Command: "echo hello",
 			},
@@ -197,6 +249,22 @@ job_template_url = "https://aap.example.com/api/v2/job_templates/9/callback/"`,
 			expectedAAP: &AAPFirstbootCustomization{
 				FirstbootCommonCustomization: FirstbootCommonCustomization{
 					Type: "aap",
+				},
+				JobTemplateURL: "https://aap.example.com/api/v2/job_templates/9/callback/",
+				HostConfigKey:  "test",
+			},
+		},
+		{
+			name: "aap-with-before",
+			json: `{"type":"aap","host_config_key":"test","before":["sssd.service"],"job_template_url":"https://aap.example.com/api/v2/job_templates/9/callback/"}`,
+			toml: `type = "aap"
+host_config_key = "test"
+before = ["sssd.service"]
+job_template_url = "https://aap.example.com/api/v2/job_templates/9/callback/"`,
+			expectedAAP: &AAPFirstbootCustomization{
+				FirstbootCommonCustomization: FirstbootCommonCustomization{
+					Type:   "aap",
+					Before: []string{"sssd.service"},
 				},
 				JobTemplateURL: "https://aap.example.com/api/v2/job_templates/9/callback/",
 				HostConfigKey:  "test",


### PR DESCRIPTION
This allows to control the order of firstboot customizations.

---

I want to refactor my firstboot refactoring and also add absolute ordering against systemd units. This was a point that @thozza brought up several times. While the initial feedback on firstboot was that this (and everything in general) should be independent of the OS, therefore the assumption that systemd is installed should not be made, I think that the practical approach is to have this. We already heard feedback from Insights customers who want to run this before that and run that after something else.

I am going for slightly vague `before` and `after` and only in the Go comment I admit that this is indeed systemd units, but this does not mean this cannot work with SysV init or pretty much anything else - these are strings and if we choose to support non-systemd OS at any point in time, the user just need to provide different strings.